### PR TITLE
attempt to mitigate banning when browsing unknown profiles

### DIFF
--- a/fint.py
+++ b/fint.py
@@ -239,12 +239,11 @@ def fill_user_ids(driver, users):
 
 # given a username, finds the fb user id from the source of the profile page
 def get_user_id(driver, username):
-
-    url = 'https://www.facebook.com/%s' % username.replace('/', '')
+    url = 'https://mbasic.facebook.com/%s' % username.replace('/', '')
     driver.get(url)
-    fbid = re.findall('fb://(profile|page)/([0-9]+)', driver.page_source)
+    fbid = re.findall(r'(?<=&amp;id=)\w+', driver.page_source)
     if fbid:
-        return fbid[0][1]
+        return fbid[0]
     else:
         print('[!] Error while getting id of user %s' % username)
         return -1


### PR DESCRIPTION
When you browse more than 100 unknown profiles, FB tends to ban you for several hours.
This patch intends to mitigate this by : 
- Scraping a list of some of your own friends
- Every 30 unknown profiles, pausing the process by surfing on well-known pages (your own wall plus a friend's page)

Not really sure if this is enough, but it can't hurt.... 